### PR TITLE
Run tests with code coverage enabled, and upload coverage to Codecov (attempt 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,17 @@ jobs:
           docker exec -t slurmctld srun -n 4 hostname
       - name: Test SlurmClusterManager
         run: |
-          docker exec -t slurmctld julia -e 'import Pkg; Pkg.activate("SlurmClusterManager"); Pkg.test()'
+          docker exec -t slurmctld /home/docker/SlurmClusterManager/ci/ci_entrypoint.bash
+      - run: find . -type f -name '*.cov'
+      - run: docker exec slurmctld /bin/bash -c 'cd /home/docker/SlurmClusterManager && tar -cf - src/*.cov' | tar -xvf -
+      - run: find . -type f -name '*.cov'
+      # - run: find . -type f -name '*.cov' -exec cat {} \;
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # If this PR is from a fork, then do NOT fail CI if the Codecov upload errors.
+          # If this PR is NOT from a fork, then DO fail CI if the Codecov upload errors.
+          # If this is not a PR, then DO fail CI if the Codecov upload errors.
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,8 @@ jobs:
         run: |
           docker exec -t slurmctld /home/docker/SlurmClusterManager/ci/ci_entrypoint.bash
       - run: find . -type f -name '*.cov'
-      - run: docker exec slurmctld /bin/bash -c 'cd /home/docker/SlurmClusterManager && tar -cf - src/*.cov' | tar -xvf -
+      - name: Copy .cov files out of the Docker container
+        run: docker exec slurmctld /bin/bash -c 'cd /home/docker/SlurmClusterManager && tar -cf - src/*.cov' | tar -xvf -
       - run: find . -type f -name '*.cov'
       # - run: find . -type f -name '*.cov' -exec cat {} \;
       - uses: julia-actions/julia-processcoverage@v1

--- a/ci/ci_entrypoint.bash
+++ b/ci/ci_entrypoint.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+set -x
+
+pwd
+
+ls -la .
+
+ls -la ./SlurmClusterManager
+
+julia --project=./SlurmClusterManager -e 'import Pkg; Pkg.instantiate()'
+
+julia --project=./SlurmClusterManager -e 'import Pkg; Pkg.status()'
+
+julia --project=./SlurmClusterManager -e 'import Pkg; Pkg.test(; coverage=true)'
+
+find . -type f -name '*.cov'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ end
   project_path = abspath(joinpath(@__DIR__, ".."))
   @info "" project_path
   jobid = withenv("JULIA_PROJECT"=>project_path) do
-    strip(read(`sbatch --export=ALL --parsable -n 4 -o test.out script.jl`, String))
+    strip(read(`sbatch --export=ALL --parsable -n 4 -o test.out script.bash`, String))
   end
   @info "" jobid
 

--- a/test/script.bash
+++ b/test/script.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+set -x
+
+pwd
+
+julia --code-coverage=user script.jl

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,5 +1,3 @@
-#!/usr/bin/env julia
-
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.
 # https://github.com/JuliaLang/julia/pull/42080


### PR DESCRIPTION
Replaces #41 (closes #41).

---

Alright, Codecov is finally working. Looks like we have 89% line coverage currently. We can work on getting that up to 100% in future PRs.

To see the code coverage, go to this URL: https://app.codecov.io/gh/JuliaParallel/SlurmClusterManager.jl/pull/42/tree

You will probably need to log into Codecov using your GitHub account.