### PR TITLE
README: Fix CI badge after repo transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SlurmClusterManager.jl
 
-![Build Status](https://github.com/kleinhenz/SlurmClusterManager.jl/workflows/CI/badge.svg)
+![Build Status](https://github.com/JuliaParallel/SlurmClusterManager.jl/actions/workflows/ci.yml/badge.svg)
 
 This package provides support for using julia within the Slurm cluster environment.
 The code is adapted from [ClusterManagers.jl](https://github.com/JuliaParallel/ClusterManagers.jl) with some modifications.


### PR DESCRIPTION
The CI badge (in the README) is red now. I wonder if it has anything to do with the repo transfer.

With this PR, the badge is green again.