### PR TITLE
Test suite: Add more test coverage for `warn_if_unexpected_params()` (only on Julia versions prior to 1.6)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,3 +60,16 @@ end
   println("# END script output")
 
 end # testset "SlurmClusterManager.jl"
+
+@testset "warn_if_unexpected_params()" begin
+  if Base.VERSION >= v"1.6"
+    # This test is not relevant for Julia 1.6+
+  else
+    params = Dict(:env => ["foo" => "bar"])
+    SlurmClusterManager.warn_if_unexpected_params(params)
+    @test_logs(
+      (:warn, "The user provided the `env` kwarg, but SlurmClusterManager.jl's support for the `env` kwarg requires Julia 1.6 or later"),
+      SlurmClusterManager.warn_if_unexpected_params(params),
+    )
+  end
+end


### PR DESCRIPTION
This is a fixed version of #45 that correctly targets `master`.