### PR TITLE
Fix some JET warnings regarding matching methods for `strip(...)` and `parse(...)`

### DIFF
--- a/src/slurmmanager.jl
+++ b/src/slurmmanager.jl
@@ -205,10 +205,12 @@ function Distributed.launch(manager::SlurmManager, params::Dict, instances_arr::
           line = readline(manager.srun_proc)
           m = match(r".*:(\d*)#(.*)", line)
           m === nothing && error("could not parse $line")
+          m[1] === nothing && error("could not extract port (m[1]) after parsing $line")
+          m[2] === nothing && error("could not extract host (m[2]) after parsing $line")
 
           config = WorkerConfig()
-          config.port = parse(Int, m[1])
-          config.host = strip(m[2])
+          config.port = parse(Int, m[1]::AbstractString)
+          config.host = strip(m[2]::AbstractString)
 
           @debug "Worker $i ready on host $(config.host), port $(config.port)"
 


### PR DESCRIPTION
Cherry-picked out of #86

```
┌ (::SlurmClusterManager.var"#25#26")() @ SlurmClusterManager /mystuff/SlurmClusterManager.jl/src/slurmmanager.jl:210
│ no matching method found `parse(::Type{Int64}, ::Nothing)` (1/2 union split): SlurmClusterManager.parse(SlurmClusterManager.Int, (m::RegexMatch{String})[1]::Union{Nothing, SubString{String}})
└────────────────────
```

```
┌ (::SlurmClusterManager.var"#25#26")() @ SlurmClusterManager /mystuff/SlurmClusterManager.jl/src/slurmmanager.jl:210
│ no matching method found `parse(::Type{Int64}, ::Nothing)` (1/2 union split): SlurmClusterManager.parse(SlurmClusterManager.Int, (m::RegexMatch{String})[1]::Union{Nothing, SubString{String}})::Int64
└────────────────────
```

```
┌ (::SlurmClusterManager.var"#25#26")() @ SlurmClusterManager /mystuff/SlurmClusterManager.jl/src/slurmmanager.jl:211
│ no matching method found `strip(::Nothing)` (1/2 union split): SlurmClusterManager.strip((m::RegexMatch{String})[2]::Union{Nothing, SubString{String}})
└────────────────────
```

```
┌ (::SlurmClusterManager.var"#25#26")() @ SlurmClusterManager /mystuff/SlurmClusterManager.jl/src/slurmmanager.jl:211
│ no matching method found `strip(::Nothing)` (1/2 union split): SlurmClusterManager.strip((m::RegexMatch{String})[2]::Union{Nothing, SubString{String}})::SubString{String}
└────────────────────
```

